### PR TITLE
Compatibility with Twitch 3rd-party addons

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,20 +4,25 @@
   "description": "Auto-click those channel point bonuses",
   "version": "0.4",
   "homepage_url": "https://github.com/trmcnvn/twitch-channel-points",
-
   "icons": {
     "16": "resources/16.png",
     "48": "resources/48.png",
     "96": "resources/96.png",
     "128": "resources/128.png"
   },
-
-  "web_accessible_resources": ["dist/src/auto-clicker.js"],
+  "web_accessible_resources": [
+    "dist/src/auto-clicker.js"
+  ],
   "content_scripts": [
     {
-      "matches": ["*://*.twitch.tv/*"],
-      "js": ["dist/src/index.js"],
-      "run_at": "document_idle"
+      "matches": [
+        "*://*.twitch.tv/*"
+      ],
+      "js": [
+        "dist/src/index.js"
+      ],
+      "run_at": "document_idle",
+      "all_frames": true
     }
   ]
 }


### PR DESCRIPTION
With this change, Twitch 3rd-party addons like [this one](https://addons.mozilla.org/en-US/firefox/addon/twitch_5/) will be compatible with this auto-clicker.