### PR TITLE
Twitch changed class name from tw-interactive to tw-button.

### DIFF
--- a/src/auto-clicker.ts
+++ b/src/auto-clicker.ts
@@ -22,7 +22,7 @@
 
   function clickBonus() {
     const interactiveElement = targetNode.querySelector<HTMLButtonElement>(
-      '.tw-interactive,.tw-button'
+      '.tw-button'
     );
     if (interactiveElement !== null) {
       interactiveElement.click();

--- a/src/auto-clicker.ts
+++ b/src/auto-clicker.ts
@@ -22,7 +22,7 @@
 
   function clickBonus() {
     const interactiveElement = targetNode.querySelector<HTMLButtonElement>(
-      '.tw-interactive'
+      '.tw-interactive,.tw-button'
     );
     if (interactiveElement !== null) {
       interactiveElement.click();


### PR DESCRIPTION
This caused the reward to stop working. For compatibility, we are trying to find a button for these two classes.